### PR TITLE
PT_OPGROW: fix CUMDTT value and output format

### DIFF
--- a/Plant/SUBSTOR-Potato/PT_OPGROW.for
+++ b/Plant/SUBSTOR-Potato/PT_OPGROW.for
@@ -84,25 +84,25 @@ C=======================================================================
 C-----------------------------------------------------------------------
       DATA GROHEAD /
 !      DATA GROHEAD(1)/
-     &'! YR      Thermal CUMT Days   Days  Grow       Fresh
+     &'! YR      Thermal Cumm.   Days   Days  Grow       Fresh
      &      Dry Weight                           Pod      Phot. Grow    
      &   Leaf Shell   Spec    Canopy          Root  ³    Root Length Den
      &sity   ³ Senesced mass              ',
 
 !      DATA GROHEAD(2)/
-     &'!   and   Time Time    after  after Stage  LAI  Yield  Leaf  St
+     &'!   and   Time    Thermal after  after Stage  LAI  Yield  Leaf  St
      &em Tuber  Root  Crop  Tops DLeaf   HI   Wgt.   No.    Water     Ni
      &t.   Nit -ing   Leaf  Hght  Brdth      Depth  ³     cm3/cm3   of 
      &soil    ³    (kg/ha)                ',
 
 !      DATA GROHEAD(3)/
-     &'!     DOY         sim    plant             Mg/Ha  ³<------
+     &'!     DOY         Time    sim    plant             Mg/Ha  ³<------
      &--------- kg/Ha --------------->³      Kg/Ha        ³<Stress (0-1)
      &>³    %     %   Area    m     m           m   ³<------------------
      &------>³ Surface  Soil              ',
 
 !      DATA GROHEAD(4) / 
-     &'@YEAR DOY DTT CUMDTT   DAS    DAP   GSTD  LAID  UYAD  LWAD
+     &'@YEAR DOY DTT     CUMDTT  DAS    DAP   GSTD  LAID  UYAD  LWAD
      &SWAD  UWAD  RWAD  TWAD  CWAD  DWAD  HIAD  EWAD  E#AD  WSPD  WSGD  
      &NSTD  LN%D  SH%D  SLAD  CHTD  CWID  EWSD  RDPD  RL1D  RL2D  RL3D  
 !     &RL4D  RL5D              '/
@@ -333,7 +333,7 @@ C
      &        1.0-NSTRES,PCNL,SHELPC,SLA,CANHT,CANWH,SATFAC,
      &        (RTDEP/100),(RLV(I),I=1,5)
      &       ,NINT(CUMSENSURF), NINT(CUMSENSOIL)
- 400      FORMAT (1X,I4,1X,I3.3,1X,F4.2,1X,1X,F4.2,1X,3(1X,I5),
+ 400      FORMAT (1X,I4,1X,I3.3,1X,F4.2,3X,F6.2,3(1X,I5),
      &          1X,F5.2,1X,F5.1,7(1X,I5),1X,F5.3,2(1X,I5),
      &          3(1X,F5.3),2(1X,F5.2),1X,F5.1,2(1X,F5.2),
      &          1X,F5.3,6(1X,F5.2), 2I6)

--- a/Plant/SUBSTOR-Potato/PT_SUBSTOR.for
+++ b/Plant/SUBSTOR-Potato/PT_SUBSTOR.for
@@ -112,7 +112,8 @@ C=======================================================================
      &    BIOMAS, DEADLF, GRAINN, ISTAGE, LFWT, MDATE,    !Input
      &    NLAYR, NSTRES, PLTPOP, RLV, ROOTN, RTDEP, RTWT, !Input
      &    SATFAC, SENESCE, STMWT, STOVN, STOVWT, SWFAC,   !Input
-     &    TUBN, TUBWT, TURFAC, WTNCAN, WTNUP, XLAI, YRPLT, DTT)!Input
+     &    TUBN, TUBWT, TURFAC, WTNCAN, WTNUP, XLAI, YRPLT, DTT, !Input
+     &   CUMDTT) !Input
 
       CALL PT_OPHARV(CONTROL, ISWITCH, 
      &    AGEFAC, APTNUP, BIOMAS, GNUP, HARVFRAC, ISDATE, !Input
@@ -178,7 +179,8 @@ C=======================================================================
      &    BIOMAS, DEADLF, GRAINN, ISTAGE, LFWT, MDATE,    !Input
      &    NLAYR, NSTRES, PLTPOP, RLV, ROOTN, RTDEP, RTWT, !Input
      &    SATFAC, SENESCE, STMWT, STOVN, STOVWT, SWFAC,   !Input
-     &    TUBN, TUBWT, TURFAC, WTNCAN, WTNUP, XLAI, YRPLT, DTT) !Input
+     &    TUBN, TUBWT, TURFAC, WTNCAN, WTNUP, XLAI, YRPLT, DTT, !Input
+     &    CUMDTT) !Input
 
       CALL PT_OPHARV(CONTROL, ISWITCH, 
      &    AGEFAC, APTNUP, BIOMAS, GNUP, HARVFRAC, ISDATE, !Input
@@ -262,7 +264,8 @@ C=======================================================================
      &    BIOMAS, DEADLF, GRAINN, ISTAGE, LFWT, MDATE,    !Input
      &    NLAYR, NSTRES, PLTPOP, RLV, ROOTN, RTDEP, RTWT, !Input
      &    SATFAC, SENESCE, STMWT, STOVN, STOVWT, SWFAC,   !Input
-     &    TUBN, TUBWT, TURFAC, WTNCAN, WTNUP, XLAI, YRPLT, DTT) !Input
+     &    TUBN, TUBWT, TURFAC, WTNCAN, WTNUP, XLAI, YRPLT, DTT, !Input
+     &    CUMDTT) !Input
 
       CALL PT_OPHARV(CONTROL, ISWITCH, 
      &    AGEFAC, APTNUP, BIOMAS, GNUP, HARVFRAC, ISDATE, !Input
@@ -285,7 +288,8 @@ C=======================================================================
      &    BIOMAS, DEADLF, GRAINN, ISTAGE, LFWT, MDATE,    !Input
      &    NLAYR, NSTRES, PLTPOP, RLV, ROOTN, RTDEP, RTWT, !Input
      &    SATFAC, SENESCE, STMWT, STOVN, STOVWT, SWFAC,   !Input
-     &    TUBN, TUBWT, TURFAC, WTNCAN, WTNUP, XLAI, YRPLT, DTT) !Input
+     &    TUBN, TUBWT, TURFAC, WTNCAN, WTNUP, XLAI, YRPLT, DTT, !Input
+     &    CUMDTT) !Input
 
       CALL PT_OPHARV(CONTROL, ISWITCH, 
      &    AGEFAC, APTNUP, BIOMAS, GNUP, HARVFRAC, ISDATE, !Input


### PR DESCRIPTION
The value of CUMDTT was not being passed as an argument at the PT_OPGROW call site.