### PR TITLE
Fix DAYL and DS input to PT_BTHTIME subroutine

### DIFF
--- a/Plant/SUBSTOR-Potato/PT_BTHTIME.for
+++ b/Plant/SUBSTOR-Potato/PT_BTHTIME.for
@@ -24,7 +24,8 @@
      &    DS, TMAX, TMIN, DIF, DAYL, TBD, TOD, TCD, TSEN,     !Input
      &    TDU, ETRM)                                          !Output
       IMPLICIT NONE
-      REAL DS, TMAX, TMIN, DIF, DAYL, TBD, TOD, TCD, TSEN, TDU, ETRM  
+      INTEGER DS
+      REAL TMAX, TMIN, DIF, DAYL, TBD, TOD, TCD, TSEN, TDU, ETRM
       REAL SUNRIS, SUNSET, TMEAN, TT, ETR, TD, TU, Q10, IETR
       INTEGER I
       SAVE
@@ -44,7 +45,6 @@
       TMEAN  = (TMAX + TMIN)/2.0
       TT     = 0.0
       ETR    = 0.0
-    !  TMEAN  = XTEMP 
       
 !*---diurnal course of temperature
       DO 10 I = 1, 24
@@ -56,8 +56,7 @@
 
 !*---assuming development rate at supra-optimum temperatures during
 !*   the reproductive phase equals that at the optimum temperature
-        IF  (DS .GE. 6 .OR. DS .LE. 1) THEN
-        !IF (DS.GT.1.) THEN
+        IF (DS.GT.1.) THEN
            TD = MIN (TD,TOD)
         ELSE
            TD = TD

--- a/Plant/SUBSTOR-Potato/PT_PHENOL.for
+++ b/Plant/SUBSTOR-Potato/PT_PHENOL.for
@@ -12,8 +12,8 @@ C  06/11/2002 GH  Modified for Y2K
 C=======================================================================
 
       SUBROUTINE PT_PHENOL (
-     &    DLAYR, FILEIO, GRAINN, ISWWAT, LL, MDATE, NLAYR,!Input
-     &    NSTRES, PLTPOP, RTWT, ST, SW, SWFAC, TMAX, TMIN,!Input
+     &    WEATHER, DLAYR, FILEIO, GRAINN, ISWWAT, LL, MDATE, !Input
+     &    NLAYR, NSTRES, PLTPOP, RTWT, ST, SW, SWFAC, TMAX, TMIN,!Input
      &    TOPSN, TWILEN, XLAI, YRDOY, YRPLT, YRSIM,       !Input
      &    APTNUP, CUMDTT, DTT, GNUP, GRORT, ISDATE,       !Output
      &    ISTAGE, MAXLAI, PLANTS, RTF, SEEDRV,            !Output
@@ -38,6 +38,7 @@ C=======================================================================
       INTEGER MDATE, NDAS, NLAYR, YEAR, YRDOY, YRPLT, YRSIM
       INTEGER YREMRG
       INTEGER STGDOY(20)
+      INTEGER DS
 
       REAL APTNUP, CTII, CUMDTT, CUMSTT, DTT
       REAL GNUP, GRAINN, GRF, GRORT, GROSPR, XLAI, MAXLAI
@@ -46,9 +47,13 @@ C=======================================================================
       REAL SEEDRV, SENLA, SPGROF, SPRLAP, SPRLTH, SPRWT, SWSD
       REAL TC, TCPLUS, TEMP, TII, TMAX, TMIN, TOPSN, TOTNUP, TSPRWT
       REAL XDEPTH, XDTT, XPLANT, XSTAGE
-      REAL DS, DIF, DAYL, TBD, TOD, TCD, TSEN, TDU, ETRM 
+      REAL DIF, TBD, TOD, TCD, TSEN, TDU, ETRM
 
       REAL, DIMENSION(NL) :: DLAYR, LL, ST, SW
+      Type (WeatherType) WEATHER
+      REAL DAYL
+
+      DAYL = WEATHER % DAYL
 
 !***********************************************************************
 !***********************************************************************
@@ -108,13 +113,21 @@ C=======================================================================
 
          ! Calculate TDU
          ! define constants
-         DS = ISTAGE ! should it be XSTAGE ?
          ! DIF = ?
-         ! DAYL = ?
          TBD=5.5
          TOD=23.4
          TCD=34.6
          TSEN=1.6
+
+         ! DSSAT's ISTAGE to GECROSS DS (Development Stage) mapping
+         ! DS = 0 -> germination, emergence (ISTAGE 5, 6 & 7)
+         ! DS = 1 -> tuber initiation (ISTAGE 1)
+         ! DS = 2 -> maturity (ISTAGE 2)
+         IF (ISTAGE .GE. 5 .AND. ISTAGE .LE. 7) THEN
+             DS = 0.0
+         ELSE
+             DS = ISTAGE
+         ENDIF
 
          CALL PT_BTHTIME (
      &      DS, TMAX, TMIN, DIF, DAYL, TBD, TOD, TCD, TSEN, !Input

--- a/Plant/SUBSTOR-Potato/PT_SUBSTOR.for
+++ b/Plant/SUBSTOR-Potato/PT_SUBSTOR.for
@@ -23,9 +23,8 @@ C  08/23/2011 GH Added CO2 response for tuber growth
 !  01/26/2023 CHP Reduce compile warnings: add EXTERNAL stmts, remove 
 !                 unused variables, shorten lines. 
 C=======================================================================
-
       SUBROUTINE PT_SUBSTOR(CONTROL, ISWITCH,
-     &    CO2, EOP, HARVFRAC, NH4, NO3, SOILPROP, SRAD,   !Input
+     &    WEATHER, CO2, EOP, HARVFRAC, NH4, NO3, SOILPROP, SRAD,!Input
      &    ST, SW, TMAX, TMIN, TRWUP, TWILEN, YREND, YRPLT,!Input
      &    CANHT, HARVRES, MDATE, NSTRES, PORMIN, RLV,     !Output
      &    RWUMX, SENESCE, STGDOY, UNH4, UNO3, XLAI)       !Output
@@ -69,6 +68,7 @@ C=======================================================================
       REAL, DIMENSION(NL) :: NH4, NO3, RLV, SAT, SHF
       REAL, DIMENSION(NL) :: ST, SW, UNO3, UNH4 
 
+      TYPE (WeatherType) WEATHER
 !     P variables
       REAL PConc_Shut, PConc_Root, PConc_Shel, PConc_Seed
 
@@ -153,7 +153,7 @@ C=======================================================================
      &    CUMDEP, RLV, RTDEP)                             !Output
 
       CALL PT_PHENOL (
-     &    DLAYR, FILEIO, GRAINN, ISWWAT, LL, MDATE, NLAYR,!Input
+     &    WEATHER, DLAYR, FILEIO, GRAINN, ISWWAT, LL, MDATE, NLAYR,!Input
      &    NSTRES, PLTPOP, RTWT, ST, SW, SWFAC, TMAX, TMIN,!Input
      &    TOPSN, TWILEN, XLAI, YRDOY, YRPLT, YRSIM,  !Input
      &    APTNUP, CUMDTT, DTT, GNUP, GRORT, ISDATE,       !Output
@@ -224,8 +224,8 @@ C=======================================================================
 
       IF (YRDOY .EQ. YRPLT .OR. ISTAGE .NE. 5) THEN
         CALL PT_PHENOL (
-     &    DLAYR, FILEIO, GRAINN, ISWWAT, LL, MDATE, NLAYR,!Input
-     &    NSTRES, PLTPOP, RTWT, ST, SW, SWFAC, TMAX, TMIN,!Input
+     &    WEATHER, DLAYR, FILEIO, GRAINN, ISWWAT, LL, MDATE, !Input
+     &    NLAYR, NSTRES, PLTPOP, RTWT, ST, SW, SWFAC, TMAX, TMIN,!Input
      &    TOPSN, TWILEN, XLAI, YRDOY, YRPLT, YRSIM,       !Input
      &    APTNUP, CUMDTT, DTT, GNUP, GRORT, ISDATE,       !Output
      &    ISTAGE, MAXLAI, PLANTS, RTF, SEEDRV,            !Output

--- a/Plant/plant.for
+++ b/Plant/plant.for
@@ -549,7 +549,7 @@ C         Variables to run CASUPRO from Alt_PLANT.  FSR 07-23-03
 !     Potato
       CASE('PTSUB')
         CALL PT_SUBSTOR(CONTROL, ISWITCH,
-     &    CO2, EOP, HARVFRAC, NH4, NO3, SOILPROP, SRAD,   !Input
+     &    WEATHER, CO2, EOP, HARVFRAC, NH4, NO3, SOILPROP, SRAD, !Input
      &    ST, SW, TMAX, TMIN, TRWUP, TWILEN, YREND, YRPLT,!Input
      &    CANHT, HARVRES, MDATE, NSTRES, PORMIN, RLV,     !Output
      &    RWUMX, SENESCE, STGDOY, UNH4, UNO3, XLAI)       !Output


### PR DESCRIPTION
The DAYL information is stored in the WeatherType variable. Add changes to enable passing the DAYL data from the weather variable to the PT_BTHTIME subroutine.

Also mapped the DSSAT's ISTAGE values for different growth stages to the PT_BTHTIME's DS (develpment stage) value range of  0-to-1.